### PR TITLE
[WIP] Distributed scanning

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9,9 +9,9 @@ class Cli(cmd.Cmd):
     intro = 'Welcome to the ASSCAN admin shell. Type help or ? to list commands.\n'
     prompt = 'ASSCAN> '
 
-    def do_list_clients(self, arg):
+    def do_list_agents(self, arg):
         'Lists connected clients'
-        print('foo')
+        print(c.get_clients())
 
     def do_get_results_by_ip(self, arg):
         'Gets results for IP'

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+import cmd, mqtt
+c = mqtt.client()
+c.connect()
+c.client.loop_start()
+
+class Cli(cmd.Cmd):
+    intro = 'Welcome to the ASSCAN admin shell. Type help or ? to list commands.\n'
+    prompt = 'ASSCAN> '
+
+    def do_list_clients(self, arg):
+        'Lists connected clients'
+        print('foo')
+
+    def do_get_results_by_ip(self, arg):
+        'Gets results for IP'
+        c.result_by_type('ip', arg)
+
+    def do_get_results_by_port(self, arg):
+        'Gets results by port'
+        c.result_by_type('port', arg)
+
+    def do_everything(self, arg):
+        'Gets all results'
+        c.all_results()
+        
+    def do_bye(self, arg):
+        print('bye bye')
+        return True
+
+    def do_EOF(self, arg):
+        return True
+
+if __name__=='__main__':
+    Cli().cmdloop()
+
+c.client.loop_stop()
+    

--- a/jobdispatch.py
+++ b/jobdispatch.py
@@ -6,11 +6,9 @@ import json
 import notes
 from scanners import *
 from scrapers import *
-import re
 from os.path import join
 import collections
 import ipaddress
-re_uuid = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
 
 
 # queues for tasks of different kinds. The maxsize parameter determines

--- a/jobdispatch.py
+++ b/jobdispatch.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
+from results import *
 from multiprocessing import Process, Queue
 import json
 import notes
 from scanners import *
 from scrapers import *
-from results import *
 import re
 from os.path import join
 import collections
@@ -49,78 +49,6 @@ def get_scans():
     r.read_all('results')
     return {'scans': sorted(r.scans, key=lambda x:x['target'])}
 
-def get_results_for_ip(ip):
-    r = Results()
-    r.read_all('results')
-    result = {}
-    if ip in r.hosts.keys():
-        return {ip: r.hosts[ip]}
-    else:
-        return {}
-
-def get_results_by_port(port):
-    r = Results()
-    r.read_all()
-    return r.by_port(port)
-
-def get_filtered_results(filters):
-    prefix = filters['prefix']
-    port = filters['port']
-    service = filters['service']
-    vulns = filters['vulns']
-    screenshots = filters['screenshots']
-    notes = filters['notes']
-    r = Results()
-    r.read_all('results')
-    filtered = r.hosts
-    sys.stderr.write('count all=%d\n'%(len(filtered.keys())))
-    if prefix and len(prefix) > 0:
-        if not prefix[-1] == '.':
-            prefix += '.'
-        filtered = filter_by_prefix(filtered, prefix)
-        sys.stderr.write('count prefix=%d\n'%(len(filtered.keys())))
-    if port and len(port) > 0:
-        filtered = filter_by_port(filtered, port)
-        sys.stderr.write('count port=%d\n'%(len(filtered.keys())))
-    if service and len(service) > 0:
-        filtered = filter_by_service(filtered, service)
-        sys.stderr.write('count service=%d\n'%(len(filtered.keys())))
-    if vulns and vulns == 'true':
-        filtered = filter_by_vulns(filtered)
-        sys.stderr.write('count vulns=%d\n'%(len(filtered.keys())))
-    if screenshots and screenshots == 'true':
-        filtered = filter_by_screenshots(filtered)
-        sys.stderr.write('count screenshots=%d\n'%(len(filtered.keys())))
-    if notes and notes == 'true':
-        filtered = filter_by_having_notes(filtered)
-        sys.stderr.write('count notes=%d\n'%(len(filtered.keys())))
-    sys.stderr.write('count final=%d\n'%(len(filtered.keys())))
-    return {'ips':list(filtered.keys())}
-
-def get_all_results():
-    r = Results()
-    r.read_all('results')
-    return r.hosts
-
-def list_ips():
-    r = Results()
-    r.read_all('results')
-    return {'ips':sorted(list(r.hosts.keys()))}
-
-def get_attachment(pathcomponents):
-    if re_uuid.match(pathcomponents[0]): # some scans save files, this returns them
-        filepath = join('results', *pathcomponents)
-        if filepath.endswith('.png'):
-            self.set_header('content-type', 'image/png')
-            return open(filepath,'rb').read()
-        if filepath.endswith('.jpg'):
-            self.set_header('content-type', 'image/jpg')
-            return open(filepath,'rb').read()
-        else:
-            self.set_header('content-type', 'text/plain')
-            return open(filepath,'rb').read()
-    else:
-        return {"status": "not ok"} # what
     
     
 

--- a/jobdispatch.py
+++ b/jobdispatch.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+
+from multiprocessing import Process, Queue
+import json
+import notes
+from scanners import *
+from scrapers import *
+from results import *
+import re
+from os.path import join
+import collections
+import ipaddress
+re_uuid = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
+
+
+# queues for tasks of different kinds. The maxsize parameter determines
+# how many tasks can be active in parallel at any given time
+massqueue = Queue(maxsize = 1)
+masscount = 0
+nmapqueue = Queue(maxsize = 4)
+nmapcount = 0
+vulnqueue = Queue(maxsize = 16)
+vulncount = 0
+scraperqueue = Queue(maxsize = 8)
+scrapercount = 0
+
+alljobs = {}
+
+
+def forkjob(job, queue):
+    def task():
+        sys.stderr.write("Queueing %s\n"%job.ident)
+        queue.put(job.ident)
+        alljobs[job.ident] = job
+        job.scan()
+        del alljobs[job.ident]
+        x=queue.get()
+        sys.stderr.write('Job %s done\n'%job.ident)
+        if job.posthook:
+            sys.stderr.write('Executing post hook for job %s\n'%job.ident)
+            job.posthook()
+        sys.stderr.write("Removed %s from queue\n"%x)
+        sys.stderr.write("Queue length %d\n"%queue.qsize())
+    p = Process(target = task)
+    p.start()
+
+def get_scans():
+    r = Results()
+    r.read_all('results')
+    return {'scans': sorted(r.scans, key=lambda x:x['target'])}
+
+def get_results_for_ip(ip):
+    r = Results()
+    r.read_all('results')
+    result = {}
+    if ip in r.hosts.keys():
+        return {ip: r.hosts[ip]}
+    else:
+        return {}
+
+def get_results_by_port(port):
+    r = Results()
+    r.read_all()
+    return r.by_port(port)
+
+def get_filtered_results(filters):
+    prefix = filters['prefix']
+    port = filters['port']
+    service = filters['service']
+    vulns = filters['vulns']
+    screenshots = filters['screenshots']
+    notes = filters['notes']
+    r = Results()
+    r.read_all('results')
+    filtered = r.hosts
+    sys.stderr.write('count all=%d\n'%(len(filtered.keys())))
+    if prefix and len(prefix) > 0:
+        if not prefix[-1] == '.':
+            prefix += '.'
+        filtered = filter_by_prefix(filtered, prefix)
+        sys.stderr.write('count prefix=%d\n'%(len(filtered.keys())))
+    if port and len(port) > 0:
+        filtered = filter_by_port(filtered, port)
+        sys.stderr.write('count port=%d\n'%(len(filtered.keys())))
+    if service and len(service) > 0:
+        filtered = filter_by_service(filtered, service)
+        sys.stderr.write('count service=%d\n'%(len(filtered.keys())))
+    if vulns and vulns == 'true':
+        filtered = filter_by_vulns(filtered)
+        sys.stderr.write('count vulns=%d\n'%(len(filtered.keys())))
+    if screenshots and screenshots == 'true':
+        filtered = filter_by_screenshots(filtered)
+        sys.stderr.write('count screenshots=%d\n'%(len(filtered.keys())))
+    if notes and notes == 'true':
+        filtered = filter_by_having_notes(filtered)
+        sys.stderr.write('count notes=%d\n'%(len(filtered.keys())))
+    sys.stderr.write('count final=%d\n'%(len(filtered.keys())))
+    return {'ips':list(filtered.keys())}
+
+def get_all_results():
+    r = Results()
+    r.read_all('results')
+    return r.hosts
+
+def list_ips():
+    r = Results()
+    r.read_all('results')
+    return {'ips':sorted(list(r.hosts.keys()))}
+
+def get_attachment(pathcomponents):
+    if re_uuid.match(pathcomponents[0]): # some scans save files, this returns them
+        filepath = join('results', *pathcomponents)
+        if filepath.endswith('.png'):
+            self.set_header('content-type', 'image/png')
+            return open(filepath,'rb').read()
+        if filepath.endswith('.jpg'):
+            self.set_header('content-type', 'image/jpg')
+            return open(filepath,'rb').read()
+        else:
+            self.set_header('content-type', 'text/plain')
+            return open(filepath,'rb').read()
+    else:
+        return {"status": "not ok"} # what
+    
+    
+
+# TODO, keep counters on jobs waiting on the queue, these
+# counters only tell if the queue is full or not
+def get_jobs_overview():
+    return {'nmap': nmapqueue.qsize(),
+            'masscan': massqueue.qsize(),
+            'scrapers': scraperqueue.qsize(),
+            'vuln': vulnqueue.qsize()}
+
+# TODO is this even in use currently?
+def get_jobs_status():
+    status = {}
+    for key in alljobs.keys():
+        status[key] = alljobs[key].status
+    return status
+
+
+
+def forkjobs(jobspec):
+    print(json.dumps(jobspec, indent=4, sort_keys=True))
+    scantypes = jobspec['scantypes'] if 'scantypes' in jobspec else []
+    foundonly = jobspec['found_only'] if 'found_only' in jobspec else False
+    if foundonly == 'false' or foundonly == '0': # how stringly
+        foundonly = False
+    target = jobspec['target'] if 'target' in jobspec else None
+    mask = jobspec['mask'] if 'mask' in jobspec else None
+    maxmask = jobspec['maxmask'] if 'maxmask' in jobspec else None
+    vncpassword = jobspec['vncpassword'] if 'vncpassword' in jobspec else ''
+    username = jobspec['username'] if 'username' in jobspec else None
+    domain = jobspec['domain'] if 'domain' in jobspec else None
+    password = jobspec['password'] if 'password' in jobspec else None
+    hostkeys = None
+    if ',' in target:
+        hostkeys = target.replace(' ','').split(',')
+
+    massjobs = []
+        
+    # When submitting multiple job types in the same request and masscan is one of
+    # the scan types, we first want to perform the masscan and only after that, the
+    # other scan types, because we implictly perform other scans only against already
+    # discovered hosts.
+    # As the "already discovered" is handled here, we need to postpone finding out
+    # which hosts are discovered until the masscan is done...
+    posthook = None
+
+    if 'masscan' in scantypes and len(scantypes) > 1:
+        othertypes = scantypes[:]
+        othertypes.remove('masscan')
+        otherjobspec = jobspec.copy()
+        otherjobspec['scantypes'] = othertypes
+        otherjobspec['found_only'] = 'true'
+        scantypes = ['masscan']
+        posthook = lambda: forkjobs(otherjobspec)
+
+    
+    if not target or not mask:
+        return{'status': 'fuck off',
+               'reason': 'target or mask missing'}
+
+    for typ in scantypes:
+        if typ == 'masscan':
+            targetspec = [target + '/' + mask]
+            jobids = []
+            port = jobspec['port'] if 'port' in jobspec else None
+
+            # split a netmask N scan into smaller scans of mask M
+            # 10.0.0.0/8 with submask /9 --> two scans
+            # /16 scans are kinda ok with /19 scans, for example
+            if maxmask: 
+                targetspec = []
+                for x in ipaddress.ip_network(target + '/' + mask).subnets(new_prefix = int(maxmask)):
+                    targetspec.append(str(x.network_address) + '/' + maxmask)
+            for t in targetspec:
+                if port and len(port) > 0: # custom port
+                    job = Masscan(t, ports = port.replace(' ',''))
+                else: # default port list, see the masscan class
+                    job = Masscan(t)
+                massjobs.append(job)
+                #forkjob(job, massqueue)
+                jobids.append(job.ident)
+        elif typ == 'nmap':
+            if foundonly: # only scan hosts found earlier with masscan
+                r = Results()
+                r.read_all('results')
+                hosts = filter_by_network(r.hosts, target, mask)
+                hosts = filter_by_missing_scan(hosts, 'nmap')
+                hostkeys = list(hosts.keys())
+                n = 32
+                hostkeylists = [hostkeys[i * n:(i + 1) * n] for i in range((len(hostkeys) + n - 1) // n )]
+                jobids = []
+                for kl in hostkeylists:
+                    job = Nmap(kl)
+                    forkjob(job, nmapqueue)
+                    jobids.append(job.ident)
+            else:
+                targetspec = [target + '/' + mask]
+                jobids = []
+                if maxmask:
+                    targetspec = []
+                    for x in ipaddress.ip_network(target + '/' + mask).subnets(new_prefix = int(maxmask)):
+                        targetspec.append(str(x.network_address) + '/' + maxmask)
+                for t in targetspec:
+                    job = Nmap(t)
+                    forkjob(job, nmapqueue)
+                    jobids.append(job.ident)
+        elif typ == 'nmap-udp': # TODO missing the foundonly flag handling!
+            udp = True
+            targetspec = None
+            prefix = jobspec['prefix'] if 'prefix' in jobspec else None
+            job = Nmap(targetspec, udp=True)
+            forkjob(job, nmapqueue)
+        elif typ == 'smbvuln': # check if this still works. OTOH ms17-010 has its own checker now
+            targetspec = target + '/' + mask
+            job = SmbVuln(targetspec)
+            forkjob(job, vulnqueue)
+        elif typ == 'webscreenshot':
+            # Fetch results for target subnet, only screenshot those with open ports
+            port = jobspec['port'] if 'port' in jobspec else '80'
+            scheme = jobspec['scheme'] if 'scheme' in jobspec else 'http'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly: # better have this set, or hardcode
+                hosts = filter_by_port(hosts, port)
+            hostkeys = list(hosts.keys())
+            if mask == '32':
+                hostkeys = [target]
+            job = WebScreenshot(list(hosts.keys()), scheme, port)
+            forkjob(job, scraperqueue)
+        elif typ == 'rdpscreenshot':
+            port = jobspec['port'] if 'port' in jobspec else '3389'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly:
+                hosts = filter_by_port(hosts, port)
+            hostkeys = list(hosts.keys())
+            if mask == '32':
+                hostkeys = [target]
+            print('hostkeys %s'%str(hostkeys))
+            job = RdpScreenshot(hostkeys)
+            forkjob(job, scraperqueue)
+        elif typ == 'vncscreenshot':
+            # Fetch results for target subnet, only screenshot those with open ports
+            port = jobspec['port'] if 'port' in jobspec else '5901'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly:
+                hosts = filter_by_port(hosts, port)
+            hostkeys = list(hosts.keys())
+            if mask == '32':
+                hostkeys = [target]
+            print('hostkeys %s'%str(hostkeys))
+            job = VncScreenshot(hostkeys, port=port, password=vncpassword)
+            forkjob(job, scraperqueue)
+        elif typ == 'enum4linux':
+            # Fetch results for target subnet, only screenshot those with open ports
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hostkeys = []
+            hosts = filter_by_network(hosts, target, mask)
+            print('filtered: %s'%str(hosts.keys()))
+            if foundonly:
+                hosts = filter_by_port(hosts, '445') # should this be 139 or 445?
+            hostkeys = list(hosts.keys())
+            if mask == '32':
+                hostkeys = [target]
+            job = Enum4Linux(hostkeys)
+            forkjob(job, scraperqueue)
+        elif typ == 'snmpwalk':
+            # Fetch results for target subnet, only screenshot those with open ports
+            prefix = jobspec['prefix'] if 'prefix' in jobspec else None
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            hostkeys = list(hosts.keys())
+            if mask == '32':
+                hostkeys = [target]
+            job = Snmpwalk(hostkeys)
+            forkjob(job, scraperqueue)
+        elif typ == 'ffuf':
+            # Fetch results for target subnet, only screenshot those with open ports
+            port = jobspec['port'] if 'port' in jobspec else '80'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly:
+                sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
+                hosts = filter_by_port(hosts, port)
+                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
+            hostkeys = list(hosts.keys())
+            job = Ffuf(hostkeys, port=port)
+            forkjob(job, scraperqueue)
+        elif typ == 'bluekeep':
+            # Fetch results for target subnet, only screenshot those with open ports
+            port = '3389'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly:
+                #sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
+                hosts = filter_by_port(hosts, port)
+                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
+            hostkeys = list(hosts.keys())
+            n = 32
+            hostkeylists = [hostkeys[i * n:(i + 1) * n] for i in range((len(hostkeys) + n - 1) // n )]
+            jobids = []
+            for kl in hostkeylists:
+                job = Bluekeep(kl)
+                forkjob(job, scraperqueue)
+                jobids.append(job.ident)
+        elif typ == 'ms17_010':
+            # Fetch results for target subnet, only screenshot those with open ports
+            port = '445'
+            r = Results()
+            r.read_all('results')
+            hosts = r.hosts
+            hosts = filter_by_network(hosts, target, mask)
+            if foundonly:
+                sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
+                hosts = filter_by_port(hosts, port)
+                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
+            hostkeys = list(hosts.keys())
+            job = Ms17_010(hostkeys)
+            forkjob(job, scraperqueue)
+        elif typ == 'sleep':
+            job = SleepJob()
+            forkjob(job, nmapqueue)
+        else:
+            pass
+
+    if len(massjobs) > 0:
+        massjobs[-1].posthook = posthook
+        for job in massjobs:
+            forkjob(job, massqueue)
+    return {'status': 'ok'} # TODO, return some info of queued jobs
+
+    

--- a/mqtt.py
+++ b/mqtt.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+
+import paho.mqtt.client as mqtt
+import json
+import jobdispatch as jd
+import time
+import socket
+
+presence_channel = 'asscan/presence'
+jobs_channel = 'asscan/job'
+
+server_addr = 'mqtt1.local.lan'
+identity = 'foo-1'
+
+"""
+This module implements a MQTT based infrastructure. An ASSCAN instance
+can act either as a "server" or an "agent". Server can dispatch job (scan)
+requests, and agents receive said requests and perform scans.
+
+The supported MQTT messages are:
+# Agent announces it's online on topic asscan/presence
+{ "type": "announce-presence",
+  "clientid": "192.168.9.20",
+  "timestamp" : 1580305710.07 }
+
+# Jobs
+Server posts job spec on asscan/job
+{ "type": "start-job-request",
+  "target_nodes": [ 'foo-1', 'foo-2' ],
+  "requestid": "[uuid]",
+  "network": "192.168.9.0",
+  "netmask": "24",
+  "scantypes": [ "nmap", "rdpscreenshot" ] }
+
+Agent responds
+{ "type": "start-job-response",
+  "requestid": "[uuid]",
+  "jobid": "[another uuid]" }
+
+Note that the agent and server classes depend on an external runloop,
+which is fine, as tornado provides for that. The main application in server.py
+is supposed to call the mqtt client instance's tick() method regularly.
+Therefore, all periodic tasks can be implemented inside the tick() method.
+
+"""
+
+
+
+def agent_on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
+    client.subscribe(jobs_channel)
+
+def server_on_connect(client, userdata, flags, rc):
+    print("Connected with result code "+str(rc))
+    client.subscribe(presence_channel)
+
+    
+class agent:
+    def on_message(self, client, userdata, msg):
+        p = msg.payload.decode('utf-8')
+        print(msg.topic + ": " + p)
+        j = json.loads(msg.payload)
+        mtype = j['type']
+        if mtype == 'presence-request':
+            print("reporting presence")
+            response = { 'type': 'presence-response',
+                         'clientid': identity }
+            client.publish(presence_channel, json.dumps(response))
+        elif mtype == 'start-job-request':
+            self.startjob(j)
+
+    def startjob(self, jobdesc):
+        jd.forkjobs(jobdesc)
+            
+    def __init__(self):
+        self.client = mqtt.Client()
+        self.client.on_connect = agent_on_connect
+        self.client.on_message = lambda c, u, m: self.on_message(c, u, m)
+        self.last_presence_at = 0.0 # when did we last announce we are online
+        self.clientid = socket.gethostbyname(socket.gethostname()) # TODO maybe user configurable
+
+    def connect(self):
+        print("Connecting")
+        #print(self.client.on_connect)
+        self.client.connect(server_addr, 1883, 60)
+        #self.client.loop_forever()
+
+    def tick(self):
+        if time.time() - self.last_presence_at > 5.0:
+            payload = { 'time': time.time(),
+                        'clientid': self.clientid,
+                        'type': 'announce-presence' }
+            self.client.publish(presence_channel, json.dumps(payload))
+            self.last_presence_at = time.time()
+        self.client.loop(timeout=1.0)
+        #pass
+
+class server:
+    def on_message(self, client, userdata, msg):
+        p = msg.payload.decode('utf-8')
+        j = json.loads(msg.payload)
+        #print(json.dumps(j, sort_keys = True, indent = 4))
+        if j['type'] == 'announce-presence':
+            clientid = j['clientid']
+            timestamp = j['time']
+            #print(timestamp)
+            if not clientid in self.connected_clients:
+                print("New agent: %s"%clientid)
+            self.connected_clients[clientid] = timestamp
+            
+    def prune_clients(self):
+        for key in list(self.connected_clients.keys())[:]:
+            if time.time() - self.connected_clients[key] > 10.0:
+                print("Removing stale agent %s"%key)
+                del self.connected_clients[key]
+            
+    def startjob(self, jobdesc):
+        jobdesc['type'] = 'start-job-request'
+        self.client.publish(jobs_channel, json.dumps(jobdesc))
+            
+    def __init__(self):
+        self.client = mqtt.Client()
+        self.client.on_connect = server_on_connect
+        self.client.on_message = lambda c, u, m: self.on_message(c, u, m)
+        self.connected_clients = {}
+
+    def connect(self):
+        print("Connecting")
+        #print(self.client.on_connect)
+        self.client.connect(server_addr, 1883, 60)
+        #self.client.loop_forever()
+
+    def tick(self):
+        self.prune_clients()
+        self.client.loop(timeout=1.0)
+        #pass
+    
+
+if __name__=='__main__':
+    a = agent()
+    a.connect()
+    a.client.loop_forever()

--- a/results.py
+++ b/results.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import notes
 import ipaddress
 import os
+import jobdispatch as jd
 
 # functions to filter a results dict by criteria
 def filter_by_port(hosts, port):
@@ -97,6 +98,120 @@ def filter_by_screenshots(hosts):
             if 'screenshot' in scan['scantype']:
                 filtered[key] = hosts[key]
     return filtered
+
+def get_results(args, filters={}):
+    if args[0] == 'ip': # single result by ip, /results/ip/192.168.0.1
+        ip = args[1]
+        return get_results_for_ip(ip)
+    elif args[0] == 'port':
+        port = args[1]
+        return get_results_by_port(port)
+    elif args[0] == 'filter':
+        #sys.stderr.write('filtering: prefix=%s port=%s service=%s vulns=%s screenshots=%s\n'%(str(prefix), str(port), str(service), str(vulns), str(screenshots)))
+        return get_filtered_results(filters)
+    elif args[0] == 'all':
+        r = Results()
+        r.read_all('results')
+        return r.hosts
+    elif args[0] == 'networks': # i don't think this is used currently
+        r = Results()
+        r.read_all('results')
+        counts = collections.defaultdict(int)
+        for key in r.hosts.keys():
+            k = '.'.join(key.split('.')[:2])
+            counts[k] += 1
+        return dict(counts)
+    elif args[0] == 'ips':
+        r = Results()
+        r.read_all('results')
+        return {'ips':sorted(list(r.hosts.keys()))}
+    elif re_uuid.match(args[0]): # some scans save files, this returns them
+        filepath = join('results', *args)
+        if filepath.endswith('.png'):
+            self.set_header('content-type', 'image/png')
+            return open(filepath,'rb').read()
+        if filepath.endswith('.jpg'):
+            self.set_header('content-type', 'image/jpg')
+            return open(filepath,'rb').read()
+        else:
+            self.set_header('content-type', 'text/plain')
+            return open(filepath,'rb').read()
+    else:
+        return {"status": "not ok"} # what
+
+def get_results_for_ip(ip):
+    r = Results()
+    r.read_all('results')
+    result = {}
+    if ip in r.hosts.keys():
+        return {ip: r.hosts[ip]}
+    else:
+        return {}
+
+def get_results_by_port(port):
+    r = Results()
+    r.read_all('results')
+    return r.by_port(port)
+
+def get_filtered_results(filters):
+    prefix = filters['prefix']
+    port = filters['port']
+    service = filters['service']
+    vulns = filters['vulns']
+    screenshots = filters['screenshots']
+    notes = filters['notes']
+    r = Results()
+    r.read_all('results')
+    filtered = r.hosts
+    sys.stderr.write('count all=%d\n'%(len(filtered.keys())))
+    if prefix and len(prefix) > 0:
+        if not prefix[-1] == '.':
+            prefix += '.'
+        filtered = filter_by_prefix(filtered, prefix)
+        sys.stderr.write('count prefix=%d\n'%(len(filtered.keys())))
+    if port and len(port) > 0:
+        filtered = filter_by_port(filtered, port)
+        sys.stderr.write('count port=%d\n'%(len(filtered.keys())))
+    if service and len(service) > 0:
+        filtered = filter_by_service(filtered, service)
+        sys.stderr.write('count service=%d\n'%(len(filtered.keys())))
+    if vulns and vulns == 'true':
+        filtered = filter_by_vulns(filtered)
+        sys.stderr.write('count vulns=%d\n'%(len(filtered.keys())))
+    if screenshots and screenshots == 'true':
+        filtered = filter_by_screenshots(filtered)
+        sys.stderr.write('count screenshots=%d\n'%(len(filtered.keys())))
+    if notes and notes == 'true':
+        filtered = filter_by_having_notes(filtered)
+        sys.stderr.write('count notes=%d\n'%(len(filtered.keys())))
+    sys.stderr.write('count final=%d\n'%(len(filtered.keys())))
+    return {'ips':list(filtered.keys())}
+
+def get_all_results():
+    r = Results()
+    r.read_all('results')
+    return r.hosts
+
+def list_ips():
+    r = Results()
+    r.read_all('results')
+    return {'ips':sorted(list(r.hosts.keys()))}
+
+def get_attachment(pathcomponents):
+    if re_uuid.match(pathcomponents[0]): # some scans save files, this returns them
+        filepath = join('results', *pathcomponents)
+        if filepath.endswith('.png'):
+            self.set_header('content-type', 'image/png')
+            return open(filepath,'rb').read()
+        if filepath.endswith('.jpg'):
+            self.set_header('content-type', 'image/jpg')
+            return open(filepath,'rb').read()
+        else:
+            self.set_header('content-type', 'text/plain')
+            return open(filepath,'rb').read()
+    else:
+        return {"status": "not ok"} # what
+
 
 class Results:
     def __init__(self):

--- a/results.py
+++ b/results.py
@@ -130,17 +130,6 @@ def get_results(args, filters={}):
         r = Results()
         r.read_all('results')
         return {'ips':sorted(list(r.hosts.keys()))}
-    elif re_uuid.match(args[0]): # some scans save files, this returns them
-        filepath = join('results', *args)
-        if filepath.endswith('.png'):
-            self.set_header('content-type', 'image/png')
-            return open(filepath,'rb').read()
-        if filepath.endswith('.jpg'):
-            self.set_header('content-type', 'image/jpg')
-            return open(filepath,'rb').read()
-        else:
-            self.set_header('content-type', 'text/plain')
-            return open(filepath,'rb').read()
     else:
         return {"status": "not ok"} # what
 

--- a/results.py
+++ b/results.py
@@ -9,6 +9,11 @@ import notes
 import ipaddress
 import os
 import jobdispatch as jd
+import re
+
+
+re_uuid = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
+
 
 # functions to filter a results dict by criteria
 def filter_by_port(hosts, port):

--- a/server.py
+++ b/server.py
@@ -121,7 +121,12 @@ class JobsHandler(tornado.web.RequestHandler):
         else:
             self.write(jd.forkjobs(jobspec))
 
-
+class AgentsHandler(tornado.web.RequestHandler):
+    def get(self):
+        if state.is_server:
+            self.write(state.mclient.get_clients())
+        else:
+            self.write({})
         
 def make_app():
     return tornado.web.Application([
@@ -136,6 +141,8 @@ def make_app():
         (r"/results/(.*)", ResultsHandler),
         (r"/notes/(.*)", NotesHandler),
         (r"/api/notes/(.*)", NotesHandler),
+        (r"/agents/", AgentsHandler),
+        (r"/api/agents/", AgentsHandler),
         (r"/scans/", ScansHandler),
         (r"/api/scans/", ScansHandler),
         (r"/(.*)", tornado.web.StaticFileHandler, {"path": "ui/asscan/dist/",\
@@ -147,8 +154,12 @@ def main():
     
     # mqtt
     if sys.argv[1] == 'agent':
-        state.mclient = m.agent()
-        serverport = 8889
+        if len(sys.argv) == 3:
+            state.mclient = m.agent(sys.argv[2])
+            serverport = 8889
+        else:
+            print("usage: %s agent agent-id"%sys.argv[0])
+            sys.exit(0)
     elif sys.argv[1] == 'server':
         state.mclient = m.server()
         state.is_server = True

--- a/server.py
+++ b/server.py
@@ -15,42 +15,17 @@ import collections
 import ipaddress
 re_uuid = re.compile('^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}\Z', re.I)
 
-# queues for tasks of different kinds. The maxsize parameter determines
-# how many tasks can be active in parallel at any given time
-massqueue = Queue(maxsize = 1)
-masscount = 0
-nmapqueue = Queue(maxsize = 4)
-nmapcount = 0
-vulnqueue = Queue(maxsize = 16)
-vulncount = 0
-scraperqueue = Queue(maxsize = 8)
-scrapercount = 0
+import jobdispatch as jd
+import mqtt as m
 
-alljobs = {}
-
-def forkjob(job, queue):
-    def task():
-        sys.stderr.write("Queueing %s\n"%job.ident)
-        queue.put(job.ident)
-        alljobs[job.ident] = job
-        job.scan()
-        del alljobs[job.ident]
-        x=queue.get()
-        sys.stderr.write('Job %s done\n'%job.ident)
-        if job.posthook:
-            sys.stderr.write('Executing post hook for job %s\n'%job.ident)
-            job.posthook()
-        sys.stderr.write("Removed %s from queue\n"%x)
-        sys.stderr.write("Queue length %d\n"%queue.qsize())
-    p = Process(target = task)
-    p.start()
+class dummy:
+    pass
+state = dummy()
+state.is_server = False
 
 class ScansHandler(tornado.web.RequestHandler):
     def get(self):
-        # Returns all past scans
-        r=Results()
-        r.read_all('results')
-        self.write({'scans': sorted(r.scans, key=lambda x:x['target'])})
+        self.write(jd.get_scans())
 
 class NotesHandler(tornado.web.RequestHandler):
     def get(self, shit):
@@ -79,52 +54,20 @@ class ResultsHandler(tornado.web.RequestHandler):
 
         if args[0] == 'ip': # single result by ip, /results/ip/192.168.0.1
             ip = args[1]
-            r = Results()
-            r.read_all('results')
-            result = {}
-            if ip in r.hosts.keys():
-                self.write({ip: r.hosts[ip]})
-            else:
-                self.write({})
+            self.write(jd.get_results_for_ip(ip))
         elif args[0] == 'port':
             port = args[1]
-            r = Results()
-            r.read_all('results')
-            self.write(r.by_port(port))
+            self.write(jd.get_results_by_port(port))
         elif args[0] == 'filter':
-            prefix = self.get_query_argument('prefix', None)
-            port = self.get_query_argument('port', None)
-            service = self.get_query_argument('service', None)
-            vulns = self.get_query_argument('vulns', None)
-            screenshots = self.get_query_argument('screenshots', None)
-            notes = self.get_query_argument('notes', None)
-            sys.stderr.write('filtering: prefix=%s port=%s service=%s vulns=%s screenshots=%s\n'%(str(prefix), str(port), str(service), str(vulns), str(screenshots)))
-            r = Results()
-            r.read_all('results')
-            filtered = r.hosts
-            sys.stderr.write('count all=%d\n'%(len(filtered.keys())))
-            if prefix and len(prefix) > 0:
-                if not prefix[-1] == '.':
-                    prefix += '.'
-                filtered = filter_by_prefix(filtered, prefix)
-                sys.stderr.write('count prefix=%d\n'%(len(filtered.keys())))
-            if port and len(port) > 0:
-                filtered = filter_by_port(filtered, port)
-                sys.stderr.write('count port=%d\n'%(len(filtered.keys())))
-            if service and len(service) > 0:
-                filtered = filter_by_service(filtered, service)
-                sys.stderr.write('count service=%d\n'%(len(filtered.keys())))
-            if vulns and vulns == 'true':
-                filtered = filter_by_vulns(filtered)
-                sys.stderr.write('count vulns=%d\n'%(len(filtered.keys())))
-            if screenshots and screenshots == 'true':
-                filtered = filter_by_screenshots(filtered)
-                sys.stderr.write('count screenshots=%d\n'%(len(filtered.keys())))
-            if notes and notes == 'true':
-                filtered = filter_by_having_notes(filtered)
-                sys.stderr.write('count notes=%d\n'%(len(filtered.keys())))
-            sys.stderr.write('count final=%d\n'%(len(filtered.keys())))
-            self.write({'ips':list(filtered.keys())})
+            filters = {}
+            filters['prefix'] = self.get_query_argument('prefix', None)
+            filters['port'] = self.get_query_argument('port', None)
+            filters['service'] = self.get_query_argument('service', None)
+            filters['vulns'] = self.get_query_argument('vulns', None)
+            filters['screenshots'] = self.get_query_argument('screenshots', None)
+            filters['notes'] = self.get_query_argument('notes', None)
+            #sys.stderr.write('filtering: prefix=%s port=%s service=%s vulns=%s screenshots=%s\n'%(str(prefix), str(port), str(service), str(vulns), str(screenshots)))
+            self.write(jd.get_filtered_results(filters))
         elif args[0] == 'all':
             r = Results()
             r.read_all('results')
@@ -162,251 +105,22 @@ class JobsHandler(tornado.web.RequestHandler):
     def get(self, shit):
         args = shit.split('/')
         if args[0] == 'overview':
-            jobs = {'nmap': nmapqueue.qsize(),
-                    'masscan': massqueue.qsize(),
-                    'scrapers': scraperqueue.qsize(),
-                    'vuln': vulnqueue.qsize()}
-            self.write(jobs)
+            self.write(jd.get_jobs_overview())
         elif args[0] == 'status':
-            status = {}
-            for key in alljobs.keys():
-                status[key] = alljobs[key].status
-            self.write(status)
+            self.write(jd.get_jobs_status())
         else:
             self.write({'error': 'fuck off'})
-            
 
     # submits a new scan job
     def post(self, dummy = None):
         jobspec = json_decode(self.request.body)
-        self.write(forkjobs(jobspec))
-
-def forkjobs(jobspec):
-    print(json.dumps(jobspec, indent=4, sort_keys=True))
-    scantypes = jobspec['scantypes'] if 'scantypes' in jobspec else []
-    foundonly = jobspec['found_only'] if 'found_only' in jobspec else False
-    if foundonly == 'false' or foundonly == '0': # how stringly
-        foundonly = False
-    target = jobspec['target'] if 'target' in jobspec else None
-    mask = jobspec['mask'] if 'mask' in jobspec else None
-    maxmask = jobspec['maxmask'] if 'maxmask' in jobspec else None
-    vncpassword = jobspec['vncpassword'] if 'vncpassword' in jobspec else ''
-    username = jobspec['username'] if 'username' in jobspec else None
-    domain = jobspec['domain'] if 'domain' in jobspec else None
-    password = jobspec['password'] if 'password' in jobspec else None
-    hostkeys = None
-    if ',' in target:
-        hostkeys = target.replace(' ','').split(',')
-
-    massjobs = []
-        
-    # When submitting multiple job types in the same request and masscan is one of
-    # the scan types, we first want to perform the masscan and only after that, the
-    # other scan types, because we implictly perform other scans only against already
-    # discovered hosts.
-    # As the "already discovered" is handled here, we need to postpone finding out
-    # which hosts are discovered until the masscan is done...
-    posthook = None
-
-    if 'masscan' in scantypes and len(scantypes) > 1:
-        othertypes = scantypes[:]
-        othertypes.remove('masscan')
-        otherjobspec = jobspec.copy()
-        otherjobspec['scantypes'] = othertypes
-        otherjobspec['found_only'] = 'true'
-        scantypes = ['masscan']
-        posthook = lambda: forkjobs(otherjobspec)
-
-    
-    if not target or not mask:
-        return{'status': 'fuck off',
-               'reason': 'target or mask missing'}
-
-    for typ in scantypes:
-        if typ == 'masscan':
-            targetspec = [target + '/' + mask]
-            jobids = []
-            port = jobspec['port'] if 'port' in jobspec else None
-
-            # split a netmask N scan into smaller scans of mask M
-            # 10.0.0.0/8 with submask /9 --> two scans
-            # /16 scans are kinda ok with /19 scans, for example
-            if maxmask: 
-                targetspec = []
-                for x in ipaddress.ip_network(target + '/' + mask).subnets(new_prefix = int(maxmask)):
-                    targetspec.append(str(x.network_address) + '/' + maxmask)
-            for t in targetspec:
-                if port and len(port) > 0: # custom port
-                    job = Masscan(t, ports = port.replace(' ',''))
-                else: # default port list, see the masscan class
-                    job = Masscan(t)
-                massjobs.append(job)
-                #forkjob(job, massqueue)
-                jobids.append(job.ident)
-        elif typ == 'nmap':
-            if foundonly: # only scan hosts found earlier with masscan
-                r = Results()
-                r.read_all('results')
-                hosts = filter_by_network(r.hosts, target, mask)
-                hosts = filter_by_missing_scan(hosts, 'nmap')
-                hostkeys = list(hosts.keys())
-                n = 32
-                hostkeylists = [hostkeys[i * n:(i + 1) * n] for i in range((len(hostkeys) + n - 1) // n )]
-                jobids = []
-                for kl in hostkeylists:
-                    job = Nmap(kl)
-                    forkjob(job, nmapqueue)
-                    jobids.append(job.ident)
-            else:
-                targetspec = [target + '/' + mask]
-                jobids = []
-                if maxmask:
-                    targetspec = []
-                    for x in ipaddress.ip_network(target + '/' + mask).subnets(new_prefix = int(maxmask)):
-                        targetspec.append(str(x.network_address) + '/' + maxmask)
-                for t in targetspec:
-                    job = Nmap(t)
-                    forkjob(job, nmapqueue)
-                    jobids.append(job.ident)
-        elif typ == 'nmap-udp': # TODO missing the foundonly flag handling!
-            udp = True
-            targetspec = None
-            prefix = jobspec['prefix'] if 'prefix' in jobspec else None
-            job = Nmap(targetspec, udp=True)
-            forkjob(job, nmapqueue)
-        elif typ == 'smbvuln': # check if this still works. OTOH ms17-010 has its own checker now
-            targetspec = target + '/' + mask
-            job = SmbVuln(targetspec)
-            forkjob(job, vulnqueue)
-        elif typ == 'webscreenshot':
-            # Fetch results for target subnet, only screenshot those with open ports
-            port = jobspec['port'] if 'port' in jobspec else '80'
-            scheme = jobspec['scheme'] if 'scheme' in jobspec else 'http'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly: # better have this set, or hardcode
-                hosts = filter_by_port(hosts, port)
-            hostkeys = list(hosts.keys())
-            if mask == '32':
-                hostkeys = [target]
-            job = WebScreenshot(list(hosts.keys()), scheme, port)
-            forkjob(job, scraperqueue)
-        elif typ == 'rdpscreenshot':
-            port = jobspec['port'] if 'port' in jobspec else '3389'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly:
-                hosts = filter_by_port(hosts, port)
-            hostkeys = list(hosts.keys())
-            if mask == '32':
-                hostkeys = [target]
-            print('hostkeys %s'%str(hostkeys))
-            job = RdpScreenshot(hostkeys)
-            forkjob(job, scraperqueue)
-        elif typ == 'vncscreenshot':
-            # Fetch results for target subnet, only screenshot those with open ports
-            port = jobspec['port'] if 'port' in jobspec else '5901'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly:
-                hosts = filter_by_port(hosts, port)
-            hostkeys = list(hosts.keys())
-            if mask == '32':
-                hostkeys = [target]
-            print('hostkeys %s'%str(hostkeys))
-            job = VncScreenshot(hostkeys, port=port, password=vncpassword)
-            forkjob(job, scraperqueue)
-        elif typ == 'enum4linux':
-            # Fetch results for target subnet, only screenshot those with open ports
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hostkeys = []
-            hosts = filter_by_network(hosts, target, mask)
-            print('filtered: %s'%str(hosts.keys()))
-            if foundonly:
-                hosts = filter_by_port(hosts, '445') # should this be 139 or 445?
-            hostkeys = list(hosts.keys())
-            if mask == '32':
-                hostkeys = [target]
-            job = Enum4Linux(hostkeys)
-            forkjob(job, scraperqueue)
-        elif typ == 'snmpwalk':
-            # Fetch results for target subnet, only screenshot those with open ports
-            prefix = jobspec['prefix'] if 'prefix' in jobspec else None
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            hostkeys = list(hosts.keys())
-            if mask == '32':
-                hostkeys = [target]
-            job = Snmpwalk(hostkeys)
-            forkjob(job, scraperqueue)
-        elif typ == 'ffuf':
-            # Fetch results for target subnet, only screenshot those with open ports
-            port = jobspec['port'] if 'port' in jobspec else '80'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly:
-                sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
-                hosts = filter_by_port(hosts, port)
-                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
-            hostkeys = list(hosts.keys())
-            job = Ffuf(hostkeys, port=port)
-            forkjob(job, scraperqueue)
-        elif typ == 'bluekeep':
-            # Fetch results for target subnet, only screenshot those with open ports
-            port = '3389'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly:
-                #sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
-                hosts = filter_by_port(hosts, port)
-                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
-            hostkeys = list(hosts.keys())
-            n = 32
-            hostkeylists = [hostkeys[i * n:(i + 1) * n] for i in range((len(hostkeys) + n - 1) // n )]
-            jobids = []
-            for kl in hostkeylists:
-                job = Bluekeep(kl)
-                forkjob(job, scraperqueue)
-                jobids.append(job.ident)
-        elif typ == 'ms17_010':
-            # Fetch results for target subnet, only screenshot those with open ports
-            port = '445'
-            r = Results()
-            r.read_all('results')
-            hosts = r.hosts
-            hosts = filter_by_network(hosts, target, mask)
-            if foundonly:
-                sys.stderr.write('0: %s\n'%str(list(hosts.keys())))
-                hosts = filter_by_port(hosts, port)
-                sys.stderr.write('1: %s\n'%str(list(hosts.keys())))
-            hostkeys = list(hosts.keys())
-            job = Ms17_010(hostkeys)
-            forkjob(job, scraperqueue)
-        elif typ == 'sleep':
-            job = SleepJob()
-            forkjob(job, nmapqueue)
+        print(json.dumps(jobspec, indent = 4, sort_keys = True))
+        if state.is_server:
+            print("I'm a server")
+            state.mclient.startjob(jobspec)
         else:
-            pass
+            self.write(jd.forkjobs(jobspec))
 
-    if len(massjobs) > 0:
-        massjobs[-1].posthook = posthook
-        for job in massjobs:
-            forkjob(job, massqueue)
-    return {'status': 'ok'} # TODO, return some info of queued jobs
 
         
 def make_app():
@@ -429,9 +143,30 @@ def make_app():
     ])
 
 def main():
+    serverport = 8888
+    
+    # mqtt
+    if sys.argv[1] == 'agent':
+        state.mclient = m.agent()
+        serverport = 8889
+    elif sys.argv[1] == 'server':
+        state.mclient = m.server()
+        state.is_server = True
+    else:
+        print('usage: %s [ server | client ]'%sys.argv[0])
+        sys.exit(0)
+
     app = make_app()
-    app.listen(8888, address='127.0.0.1') # better not expose this
-    tornado.ioloop.IOLoop.current().start()
+    app.listen(serverport, address='127.0.0.1') # better not expose this
+    c = tornado.ioloop.PeriodicCallback(lambda: state.mclient.tick(), callback_time = 1000.0)
+    c.start()
+    print("mqtt client running: " + str(c.is_running()))
+    try:
+        state.mclient.connect()
+        tornado.ioloop.IOLoop.current().start()
+    except:
+        print("Stopping callback")
+        c.stop()
 
 if __name__ == "__main__":
     main()

--- a/server.py
+++ b/server.py
@@ -51,53 +51,14 @@ class ResultsHandler(tornado.web.RequestHandler):
         # Returns results from all scans
         # The web UI only uses the /filter? api
         args = shit.split('/')
-
-        if args[0] == 'ip': # single result by ip, /results/ip/192.168.0.1
-            ip = args[1]
-            self.write(jd.get_results_for_ip(ip))
-        elif args[0] == 'port':
-            port = args[1]
-            self.write(jd.get_results_by_port(port))
-        elif args[0] == 'filter':
-            filters = {}
-            filters['prefix'] = self.get_query_argument('prefix', None)
-            filters['port'] = self.get_query_argument('port', None)
-            filters['service'] = self.get_query_argument('service', None)
-            filters['vulns'] = self.get_query_argument('vulns', None)
-            filters['screenshots'] = self.get_query_argument('screenshots', None)
-            filters['notes'] = self.get_query_argument('notes', None)
-            #sys.stderr.write('filtering: prefix=%s port=%s service=%s vulns=%s screenshots=%s\n'%(str(prefix), str(port), str(service), str(vulns), str(screenshots)))
-            self.write(jd.get_filtered_results(filters))
-        elif args[0] == 'all':
-            r = Results()
-            r.read_all('results')
-            self.write(r.hosts)
-        elif args[0] == 'networks': # i don't think this is used currently
-            r = Results()
-            r.read_all('results')
-            counts = collections.defaultdict(int)
-            for key in r.hosts.keys():
-                k = '.'.join(key.split('.')[:2])
-                counts[k] += 1
-            self.write(dict(counts))
-        elif args[0] == 'ips':
-            r = Results()
-            r.read_all('results')
-            self.write({'ips':sorted(list(r.hosts.keys()))})
-        elif re_uuid.match(args[0]): # some scans save files, this returns them
-            filepath = join('results', *args)
-            if filepath.endswith('.png'):
-                self.set_header('content-type', 'image/png')
-                self.write(open(filepath,'rb').read())
-            if filepath.endswith('.jpg'):
-                self.set_header('content-type', 'image/jpg')
-                self.write(open(filepath,'rb').read())
-            else:
-                self.set_header('content-type', 'text/plain')
-                self.write(open(filepath,'rb').read())
-        else:
-            self.write({"status": "not ok"}) # what
-
+        filters = {}
+        filters['prefix'] = self.get_query_argument('prefix', None)
+        filters['port'] = self.get_query_argument('port', None)
+        filters['service'] = self.get_query_argument('service', None)
+        filters['vulns'] = self.get_query_argument('vulns', None)
+        filters['screenshots'] = self.get_query_argument('screenshots', None)
+        filters['notes'] = self.get_query_argument('notes', None)
+        self.write(get_results(args, filters))
     
             
 # information on current scan jobs


### PR DESCRIPTION
Agent/server model using MQTT.

The idea is that multiple agents can be deployed in different parts of the network
and be controlled from a central server. Having the agents receive job requests
from an MQTT broker should be easier than routing HTTP to the agents.

This commit has
- REST API (server.py) refactored a bit so that the requesthandler subclasses
  mainly handle HTTP and actual business logic is elsewhere, such as the job
  dispatch logic
- the main app starts an mqtt client either in server or agent mode
- note that the mqtt client expects to be supported by an external runloop
  (this is the case currently)
- currently submitting jobs to a server causes them be relayed to an agent

TODO:
- provide an agent list on the GUI
- GUI to have option to start jobs either at server, or at agents or maybe both
- figure out how to access the scan results of agents